### PR TITLE
Do not check for ruby/encoding.h, if we are running under Ruby 1.8.7

### DIFF
--- a/ext/unf_ext/extconf.rb
+++ b/ext/unf_ext/extconf.rb
@@ -1,6 +1,6 @@
 require 'mkmf'
 have_library('stdc++')
-have_header('ruby/encoding.h')
+have_header('ruby/encoding.h') if RUBY_VERSION > '1.9.'
 create_makefile 'unf_ext'
 
 unless CONFIG['CXX']


### PR DESCRIPTION
Prevents /usr/include/ruby/encoding.h from being incorrectly detected when compiling under Ruby 1.8.7.
