### PR TITLE
fix compile with gcc 6.x on armv7hl

### DIFF
--- a/ext/unf_ext/extconf.rb
+++ b/ext/unf_ext/extconf.rb
@@ -6,6 +6,8 @@ else
   have_library('stdc++')
 end
 
+$CXXFLAGS += ' -ansi'
+
 create_makefile 'unf_ext'
 
 unless CONFIG['CXX']


### PR DESCRIPTION
The default mode in gcc 6 for C++ is now `-std=gnu++14` instead of `-std=gnu++98`.

Fixes #15.
