### PR TITLE
Add the -fsigned-char tweak to 'aarch64' architecture.

### DIFF
--- a/ext/unf_ext/extconf.rb
+++ b/ext/unf_ext/extconf.rb
@@ -7,7 +7,7 @@ else
 end
 
 case RUBY_PLATFORM
-when /\Aarm/
+when /\A(arm|aarch64) /
   # A quick fix for char being unsigned by default on ARM
   if defined?($CXXFLAGS)
     $CXXFLAGS << ' -fsigned-char'


### PR DESCRIPTION
Needed to compile on odroid-c2 for example.