### PR TITLE
Fix tests

### DIFF
--- a/test/test_unf_ext.rb
+++ b/test/test_unf_ext.rb
@@ -12,30 +12,30 @@ class TestUnf < Test::Unit::TestCase
     normalizer = UNF::Normalizer.new
     open(Pathname(__FILE__).dirname + 'normalization-test.txt', 'r:utf-8').each_slice(6) { |lines|
       flunk "broken test file" if lines.size != 6 || lines.pop !~ /^$/
-      str, nfd, nfc, nfkd, nfkc = lines
-      assert nfd,  normalizer.normalize(str,  :nfd)
-      assert nfd,  normalizer.normalize(nfd,  :nfd)
-      assert nfd,  normalizer.normalize(nfc,  :nfd)
-      assert nfkd, normalizer.normalize(nfkc, :nfd)
-      assert nfkd, normalizer.normalize(nfkc, :nfd)
+      str, nfc, nfd, nfkc, nfkd = lines
+      assert_equal nfd,  normalizer.normalize(str,  :nfd)
+      assert_equal nfd,  normalizer.normalize(nfd,  :nfd)
+      assert_equal nfd,  normalizer.normalize(nfc,  :nfd)
+      assert_equal nfkd, normalizer.normalize(nfkc, :nfd)
+      assert_equal nfkd, normalizer.normalize(nfkc, :nfd)
 
-      assert nfc,  normalizer.normalize(str,  :nfd)
-      assert nfc,  normalizer.normalize(nfd,  :nfc)
-      assert nfc,  normalizer.normalize(nfc,  :nfc)
-      assert nfkc, normalizer.normalize(nfkc, :nfc)
-      assert nfkc, normalizer.normalize(nfkd, :nfc)
+      assert_equal nfc,  normalizer.normalize(str,  :nfc)
+      assert_equal nfc,  normalizer.normalize(nfd,  :nfc)
+      assert_equal nfc,  normalizer.normalize(nfc,  :nfc)
+      assert_equal nfkc, normalizer.normalize(nfkc, :nfc)
+      assert_equal nfkc, normalizer.normalize(nfkd, :nfc)
 
-      assert nfkd, normalizer.normalize(str,  :nfkd)
-      assert nfkd, normalizer.normalize(nfd,  :nfkd)
-      assert nfkd, normalizer.normalize(nfc,  :nfkd)
-      assert nfkd, normalizer.normalize(nfkc, :nfkd)
-      assert nfkd, normalizer.normalize(nfkd, :nfkd)
+      assert_equal nfkd, normalizer.normalize(str,  :nfkd)
+      assert_equal nfkd, normalizer.normalize(nfd,  :nfkd)
+      assert_equal nfkd, normalizer.normalize(nfc,  :nfkd)
+      assert_equal nfkd, normalizer.normalize(nfkc, :nfkd)
+      assert_equal nfkd, normalizer.normalize(nfkd, :nfkd)
 
-      assert nfkc, normalizer.normalize(str,  :nfkc)
-      assert nfkc, normalizer.normalize(nfd,  :nfkc)
-      assert nfkc, normalizer.normalize(nfc,  :nfkc)
-      assert nfkc, normalizer.normalize(nfkc, :nfkc)
-      assert nfkc, normalizer.normalize(nfkd, :nfkc)
+      assert_equal nfkc, normalizer.normalize(str,  :nfkc)
+      assert_equal nfkc, normalizer.normalize(nfd,  :nfkc)
+      assert_equal nfkc, normalizer.normalize(nfc,  :nfkc)
+      assert_equal nfkc, normalizer.normalize(nfkc, :nfkc)
+      assert_equal nfkc, normalizer.normalize(nfkd, :nfkc)
     }
   end
 end


### PR DESCRIPTION
It appears that the included tests were not setting the data strings in the order provided by the `normalization-test.txt` file (unnormalized, nfc, nfd, nfkc, nfkd) and this wasn't caught because the tests themselves were using `assert` (which only checks that the arguments are truthy) rather than `assert_equal` (which ensures that they match).

This PR fixes these issues, meaning that the tests actually test (and `unf` still passes them).