### PR TITLE
Revert special case for signed char in ARM

### DIFF
--- a/ext/unf_ext/extconf.rb
+++ b/ext/unf_ext/extconf.rb
@@ -6,17 +6,6 @@ else
   have_library('stdc++')
 end
 
-case RUBY_PLATFORM
-when /\Aarm/
-  # A quick fix for char being unsigned by default on ARM
-  if defined?($CXXFLAGS)
-    $CXXFLAGS << ' -fsigned-char'
-  else
-    # Ruby < 2.0
-    $CFLAGS << ' -fsigned-char'
-  end
-end
-
 create_makefile 'unf_ext'
 
 unless CONFIG['CXX']


### PR DESCRIPTION
There other architectures where char is not signed as well.
Since 8a6a735b51ef903200fc541112e35b7cea781856 introduces
a real fix, I think this should be reverted.