### PR TITLE
Update Solaris SPARC compile options.

### DIFF
--- a/ext/unf_ext/extconf.rb
+++ b/ext/unf_ext/extconf.rb
@@ -4,6 +4,18 @@ if with_config('static-libstdc++')
   $LDFLAGS << ' ' << `#{CONFIG['CC']} -print-file-name=libstdc++.a`.chomp
 else
   have_library('stdc++')
+  # Do a little trickery here to enable C++ standard on Solaris 11 if found.
+  # This also forces 64bit compilation mode.
+  if (RbConfig::CONFIG['host_os'] =~ /solaris(!?2.11)/)
+    $CXX = CONFIG['CXX']
+    $CXX << ' ' << '-m64'
+    $CFLAGS = CONFIG['CFLAGS'].gsub(/-std=c99/, '')
+    $CFLAGS << ' ' << '-m64 -std=c++11'
+    $CPPFLAGS = CONFIG['CFLAGS'].gsub(/-std=c99/, '')
+    $CPPFLAGS << ' ' << '-m64 -std=c++11'
+    $CXXFLAGS = CONFIG['CFLAGS'].gsub(/-std=c99/, '')
+    $CXXFLAGS << ' ' << '-m64 -std=c++11'
+  end
 end
 
 create_makefile 'unf_ext'


### PR DESCRIPTION
This solves part of https://github.com/knu/ruby-unf_ext/issues/32 based almost entirely on the solution that @MarkGibbons provided. Since SPARC is technically a 64bit operating system by default, this seems reasonable.

Signed-off-by: Scott Hain <shain@chef.io>

@markgibbons I am happy to add an Authored by or amend commits for full attribution if you'd prefer!