### PR TITLE
compiler flags necessary for AIX

### DIFF
--- a/ext/unf_ext/extconf.rb
+++ b/ext/unf_ext/extconf.rb
@@ -4,6 +4,14 @@ if with_config('static-libstdc++')
   $LDFLAGS << ' ' << `#{CONFIG['CC']} -print-file-name=libstdc++.a`.chomp
 else
   have_library('stdc++')
+
+  if RbConfig::CONFIG['host_os'] =~ /aix/
+    # Compiler flags necessary on AIX.
+    # rubocop:disable Style/GlobalVars
+    $CFLAGS << ' ' << '-D_ALL_SOURCE=1'
+    $CPPFLAGS << ' ' << '-D_ALL_SOURCE=1'
+    $CXXFLAGS << ' ' << '-D_ALL_SOURCE=1'
+  end
 end
 
 create_makefile 'unf_ext'


### PR DESCRIPTION
### :nut_and_bolt: Description

We discovered some compiler flags necessary for gem usage on AIX platforms.
This has been tested successfully in our environment:

```
========================================
= Tool Versions on aix aix-7 x86_64 builder powerpc
========================================

Bash.........GNU bash, version 4.3.30(1)-release (powerpc-ibm-aix6.1.0.0)
Bundler......Bundler version 1.16.0
XLC..........IBM XL C/C++ for AIX, V13.1 (5725-C72, 5765-J07)
Git..........git version 2.14.1
Make.........GNU Make 4.1
Ruby.........ruby 2.4.2p198 (2017-09-14 revision 59899) [powerpc-aix6.1.0.0]
RubyGems.....2.6.14
```


### :white_check_mark: Checklist

- [x] Code actually executed - gem native extensions compile?
- [x] Vetting performed (unit tests, lint, etc.)?

Signed-off-by: Jeremy J. Miller <jm@chef.io>