### PR TITLE
Add links to gemspec

### DIFF
--- a/unf_ext.gemspec
+++ b/unf_ext.gemspec
@@ -39,4 +39,13 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("bundler", [">= 1.2"])
   gem.add_development_dependency("rake-compiler", [">= 0.7.9"])
   gem.add_development_dependency("rake-compiler-dock", ["~> 0.7.0"])
+  
+  if gem.respond_to?(:metadata)
+    gem.metadata = {
+      "bug_tracker_uri" => "https://github.com/knu/ruby-unf_ext/issues",
+      "changelog_uri"   => "https://github.com/knu/ruby-unf_ext/blob/master/CHANGELOG.md",
+      "homepage_uri"    => "https://github.com/knu/ruby-unf_ext",
+      "source_code_uri" => "https://github.com/knu/ruby-unf_ext"
+    }
+  end
 end


### PR DESCRIPTION
This publishes the direct links on rubygems website. Also allows easier automation around gem updates.