### PR TITLE
Add Ruby 2.7 to Travis-CI matrix / Drop Ruby 1.8.7 from testmatrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.8.7
   - ree
   - 1.9.3
   - 2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - ruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
Ruby 2.7 got released some time ago. The first distributions start to
ship it, so I think we should test against it.