### PR TITLE
Add GitHub Actions, trim jobs from Travis

### DIFF
--- a/.github/workflows/unf_ext.yml
+++ b/.github/workflows/unf_ext.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: >-
+      ${{ matrix.os }} ${{ matrix.ruby }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04, macos-11.0, windows-2019 ]
+        ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, head ]
+        include:
+          - { os: windows-2019, ruby: mingw }
+        exclude:
+          - { os: macos-11.0  , ruby: 2.2   }
+          - { os: macos-11.0  , ruby: 2.3   }
+          - { os: windows-2019, ruby: head  }
+
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v2
+
+      - name: load ruby, ragel
+        uses: MSP-Greg/setup-ruby-pkgs@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          mingw: _upgrade_
+
+      - name:  bundle install
+        shell: pwsh
+        run:   |
+          # update RubyGems in Ruby 2.2, bundle install
+          if ('${{ matrix.ruby }}' -lt '2.3') {
+            gem update --system 2.7.10 --no-document
+          }
+          bundle config set --local path .bundle/vendor
+          bundle install --jobs 4 --retry 3
+
+      - name: compile
+        timeout-minutes: 5
+        run:  bundle exec rake compile
+
+      - name: test
+        timeout-minutes: 5
+        run:  bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,7 @@ rvm:
   - 1.9.3
   - 2.0
   - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
-  - 2.6
-  - 2.7
-  - ruby-head
 matrix:
-  allow_failures:
-    - rvm: ruby-head
 before_install:
   - gem update --system --conservative || gem install --conservative bundler -v '<2'
 before_script:


### PR DESCRIPTION
I saw an issue elsewhere where the user was having macOS gem install issues, probably some issue with build tools.  Thought Actions CI might be helpful.

Actions doesn't currently have an equivalent of Travis' 'allow-failure', but the 'head/master' builds in Actions are fully tested.  At one time that wasn't the case with Travis.  All are currently passing (Ubuntu, macOS, & Windows).

**Edit:** Forgot to mention.  If a repo does not have an Actions workflow, a PR adding one will not run it.  See https://github.com/MSP-Greg/ruby-unf_ext/actions/runs/373679980