### PR TITLE
Add cross compilation for Ruby 3.2

### DIFF
--- a/unf_ext.gemspec
+++ b/unf_ext.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("test-unit")
   gem.add_development_dependency("rdoc", ["> 2.4.2"])
   gem.add_development_dependency("bundler", [">= 1.2"])
-  gem.add_development_dependency("rake-compiler", [">= 1.1.1"])
-  gem.add_development_dependency("rake-compiler-dock", [">= 1.2.1"])
+  gem.add_development_dependency("rake-compiler", [">= 1.2.1"])
+  gem.add_development_dependency("rake-compiler-dock", [">= 1.3.0"])
 end


### PR DESCRIPTION
@knu please merge this PR and release new a cross-compiled version supporting Ruby 3.2. It seems in particular `x64-mingw-ucrt` is not being supported for Ruby 3.2.