### PR TITLE
Remove development and test files from the gem package

### DIFF
--- a/unf_ext.gemspec
+++ b/unf_ext.gemspec
@@ -12,9 +12,11 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/knu/ruby-unf_ext"
   gem.licenses      = ["MIT"]
 
-  gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/}).grep(%r{/test_[^/]+\.rb$})
+  gem.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |file|
+      file.start_with?(*%w[. Gemfile Rakefile test unf_ext.gemspec])
+    end
+  end
   gem.require_paths = ["lib"]
   gem.extensions    = ["ext/unf_ext/extconf.rb"]
 


### PR DESCRIPTION
There are a number of files in the gem package that aren't useful for downstream projects. Removing these reduces the gem package size from **390K** to **273K**!


```diff
< .document
< .github/workflows/unf_ext.yml
< .gitignore
  CHANGELOG.md
< Gemfile
  LICENSE.txt
  README.md
< Rakefile
  ext/unf_ext/extconf.rb
  ext/unf_ext/unf.cc
  ext/unf_ext/unf/normalizer.hh
  ext/unf_ext/unf/table.hh
  ext/unf_ext/unf/trie/char_stream.hh
  ext/unf_ext/unf/trie/node.hh
  ext/unf_ext/unf/trie/searcher.hh
  ext/unf_ext/unf/util.hh
  lib/unf_ext.rb
  lib/unf_ext/version.rb
< test/helper.rb
< test/normalization-test.txt
< test/test_unf_ext.rb
< unf_ext.gemspec
```

