### PR TITLE
Fix use of designated initializers.

### DIFF
--- a/ext/unf_ext/unf.cc
+++ b/ext/unf_ext/unf.cc
@@ -33,8 +33,14 @@ extern "C" {
   static const rb_data_type_t unf_normalizer_data_type = {
     .wrap_struct_name = "UNF::Normalizer",
     .function = {
-      .dfree = unf_delete
+      .dmark = NULL,
+      .dfree = unf_delete,
+      .dsize = NULL,
+      .dcompact = NULL,
+      .reserved = {NULL}
     },
+    .parent = NULL,
+    .data = NULL,
     .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
   };
 

--- a/ext/unf_ext/unf.cc
+++ b/ext/unf_ext/unf.cc
@@ -35,9 +35,7 @@ extern "C" {
     .function = {
       .dmark = NULL,
       .dfree = unf_delete,
-      .dsize = NULL,
-      .dcompact = NULL,
-      .reserved = {NULL}
+      .dsize = NULL
     },
     .parent = NULL,
     .data = NULL,


### PR DESCRIPTION
Make them compatible with earlier versions of GCC.

Fixes #74.