### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/unf_ext

### DIFF
--- a/unf_ext.gemspec
+++ b/unf_ext.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("bundler", [">= 1.2"])
   gem.add_development_dependency("rake-compiler", [">= 1.2.1"])
   gem.add_development_dependency("rake-compiler-dock", [">= 1.3.0"])
+
+  gem.metadata["changelog_uri"] = gem.homepage + "/blob/master/CHANGELOG.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/unf_ext which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/